### PR TITLE
fix: 'Missing required argument' when using image_uri

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -16,7 +16,7 @@ locals {
   output_zip_file = local.enabled && var.zip.enabled ? "${path.module}/lambdas/${random_pet.zip_recreator[0].id}.zip" : null
 
   cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
-  s3_key             = var.s3_key != null ? var.s3_key : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example"))
+  s3_key             = var.s3_key != null ? var.s3_key : (var.image_uri != null ? null : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")))
 }
 
 data "aws_ssm_parameter" "cicd_ssm_param" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
While applying Lambda component from image_uri next error reported: "s3_key": all of `s3_bucket,s3_key` must be specified
The reason for this problem is that locals.s3_key is always not null, which conflicts with not null image_url
(see [cloudposse/lambda-function/aws](https://github.com/cloudposse/terraform-aws-lambda-function/blob/302a4d51364735edac015baa372efcbf35da5722/variables.tf#L86)).
The solution is to add a additional check when generating locals.s3_key

how to reproduce
```yaml
components:
  terraform:
    lambda2-test/lambda:
      metadata:
        component: lambda
      vars:
        name: my-service-lambda-test
        service_name: lambda2-test
        package_type: Image
        timeout: 15
        image_uri: "778631511111.dkr.ecr.us-east-1.amazonaws.com/hello:latest"
        image_config:
          command:
            - "test.handler.handler"
```

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
Lambda component should work with image_url variable

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal asset handling to better manage image inputs, ensuring more streamlined processing in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->