### PR TITLE
Feature: Allow lambda images to utilize the `ssm_param_name` variable

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -32,7 +32,7 @@ data "aws_ssm_parameter" "cicd_ssm_param" {
 module "iam_policy" {
   count   = local.iam_policy_enabled ? 1 : 0
   source  = "cloudposse/iam-policy/aws"
-  version = "1.0.1"
+  version = "2.0.2"
 
   iam_policy_enabled          = true
   iam_policy                  = var.iam_policy

--- a/src/main.tf
+++ b/src/main.tf
@@ -17,6 +17,10 @@ locals {
 
   cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
   s3_key             = var.s3_key != null ? var.s3_key : (var.image_uri != null ? null : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")))
+
+  # If cicd_ssm_param_name is set, use the value from the SSM parameter to format the image_uri
+  # This is useful when you want to deploy a lambda whos tag is stored in a SSM parameter
+  image_uri = (var.cicd_ssm_param_name != null && var.image_uri != null && strcontains(var.image_uri, "%s")) ? format(var.image_uri, one(data.aws_ssm_parameter.cicd_ssm_param[*].value)) : var.image_uri
 }
 
 data "aws_ssm_parameter" "cicd_ssm_param" {
@@ -28,7 +32,7 @@ data "aws_ssm_parameter" "cicd_ssm_param" {
 module "iam_policy" {
   count   = local.iam_policy_enabled ? 1 : 0
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.2"
+  version = "1.0.1"
 
   iam_policy_enabled          = true
   iam_policy                  = var.iam_policy
@@ -70,7 +74,7 @@ module "lambda" {
   description        = var.description
   handler            = var.handler
   lambda_environment = var.lambda_environment
-  image_uri          = var.image_uri
+  image_uri          = local.image_uri
   image_config       = var.image_config
 
   filename          = var.zip.enabled ? coalesce(data.archive_file.lambdazip[0].output_path, var.filename) : var.filename

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -263,7 +263,7 @@ variable "policy_json" {
 }
 
 variable "iam_policy" {
-  type = object({
+  type = list(object({
     policy_id = optional(string, null)
     version   = optional(string, null)
     statements = list(object({
@@ -287,9 +287,14 @@ variable "iam_policy" {
         identifiers = list(string)
       })), [])
     }))
-  })
-  description = "IAM policy to attach to the Lambda role, specified as a Terraform object. This can be used with or instead of `var.policy_json`."
-  default     = null
+  }))
+  description = <<-EOT
+    IAM policy as list of Terraform objects, compatible with Terraform `aws_iam_policy_document` data source
+    except that `source_policy_documents` and `override_policy_documents` are not included.
+    Use inputs `iam_source_policy_documents` and `iam_override_policy_documents` for that.
+    EOT
+  default     = []
+  nullable    = false
 }
 
 variable "zip" {


### PR DESCRIPTION
This pull request introduces enhancements to the Terraform module for managing AWS Lambda functions. Key updates include support for dynamically formatting `image_uri` using SSM parameters, a refactor of the `iam_policy` variable to improve compatibility and usability, and minor adjustments to ensure consistent behavior. Below are the most important changes grouped by theme:

### Lambda Deployment Enhancements:
* Added logic to dynamically format `image_uri` using the value of an SSM parameter when `cicd_ssm_param_name` is set. This allows deploying Lambda functions with tags stored in SSM parameters (`src/main.tf`, [src/main.tfR20-R23](diffhunk://#diff-1956abf05e8db0150fc12428093f137d1e9cca0a1d2d780a890c054274fb1e30R20-R23)).
* Updated the `module "lambda"` block to use the newly defined `local.image_uri` instead of directly referencing `var.image_uri` (`src/main.tf`, [src/main.tfL73-R77](diffhunk://#diff-1956abf05e8db0150fc12428093f137d1e9cca0a1d2d780a890c054274fb1e30L73-R77)).

### IAM Policy Improvements:
* References: https://github.com/cloudposse/terraform-aws-iam-policy/blob/main/variables.tf#L1-L34
* Refactored the `iam_policy` variable type from a single object to a list of objects for better compatibility with the Terraform `aws_iam_policy_document` data source (`src/variables.tf`, [src/variables.tfL266-R266](diffhunk://#diff-e64d396480ef61e94c68b45e4940f63bdb28cce844c90404d648122910254904L266-R266)).
* Updated the `iam_policy` variable description to clarify usage and added `nullable = false` with a default value of an empty list for stricter validation (`src/variables.tf`, [src/variables.tfL290-R297](diffhunk://#diff-e64d396480ef61e94c68b45e4940f63bdb28cce844c90404d648122910254904L290-R297)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled dynamic substitution in the image URI using values from AWS SSM parameters for Lambda deployments.

* **Improvements**
  * Updated IAM policy input to accept a list of policy objects instead of a single object, allowing for more flexible policy definitions.
  * Improved documentation for the IAM policy variable to clarify its structure and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->