### PR TITLE
Change scaling_config to dynamic block

### DIFF
--- a/src/triggers_sqs_queue.tf
+++ b/src/triggers_sqs_queue.tf
@@ -65,9 +65,13 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
   function_name    = module.lambda.function_name
   batch_size       = each.value.batch_size == null ? 1 : each.value.batch_size
 
-  scaling_config {
-    maximum_concurrency = each.value.maximum_concurrency
+  dynamic "scaling_config" {
+    for_each = each.value.maximum_concurrency != null ? [1] : []
+    content {
+      maximum_concurrency = each.value.maximum_concurrency
+    }
   }
+
   dynamic "destination_config" {
     for_each = { for k, v in each.value : k => v if k == "on_failure_arn" && v != null }
     content {


### PR DESCRIPTION
## what
* Changes the `scaling_config` block to a dynamic config that defaults to `null`

## why
* If an SQS trigger is used, but no `scaling_config` variable is passed, we'll see a constant no-op drift in Terraform trying to apply `scaling_config` that looks like:

  ```hcl
  # aws_lambda_event_source_mapping.event_source_mapping["foo"] will be updated in-place
  ~ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
        id                                 = "1234"
        tags                               = {}
        # (21 unchanged attributes hidden)

      + scaling_config {}
    }
  ```

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping#scaling_config-configuration-block


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Lambda event source mapping configuration to make scaling settings optional, enabling deployments to only apply concurrency limits when explicitly configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->