### PR TITLE
Improve s3_key assignment based on conditions

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -17,10 +17,12 @@ locals {
 
   cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
   # Only set s3_key when both bucket and key are set or not required for Image type
-  s3_key = (
-    (var.s3_key != null && local.s3_bucket_name != null) ? var.s3_key :
-    (var.image_uri != null ? null : (local.s3_bucket_name != null ? format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")) : null))
+  s3_key = local.s3_bucket_name == null ? null : (
+    var.s3_key != null ? var.s3_key : (
+      var.image_uri != null ? null : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example"))
+    )
   )
+
 
   # If cicd_ssm_param_name is set, use the value from the SSM parameter to format the image_uri
   # This is useful when you want to deploy a lambda whos tag is stored in a SSM parameter

--- a/src/main.tf
+++ b/src/main.tf
@@ -16,7 +16,11 @@ locals {
   output_zip_file = local.enabled && var.zip.enabled ? "${path.module}/lambdas/${random_pet.zip_recreator[0].id}.zip" : null
 
   cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
-  s3_key             = var.s3_key != null ? var.s3_key : (var.image_uri != null ? null : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")))
+  # Only set s3_key when both bucket and key are set or not required for Image type
+  s3_key = (
+    (var.s3_key != null && local.s3_bucket_name != null) ? var.s3_key :
+    (var.image_uri != null ? null : (local.s3_bucket_name != null ? format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")) : null))
+  )
 
   # If cicd_ssm_param_name is set, use the value from the SSM parameter to format the image_uri
   # This is useful when you want to deploy a lambda whos tag is stored in a SSM parameter


### PR DESCRIPTION
## what
* Improve s3_key assignment based on conditions

## why
* Ensure `s3_key` set `null` if `s3_bucket_name` is null

```
import:
  - catalog/lambda/defaults

components:
  terraform:
    lambda/hello-world-py:
      metadata:
        component: lambda
        inherits:
          - lambda/defaults
      vars:
        name: hello-world-py
        function_name: main
        description: Hello Lambda from Python!
        handler: lambda.lambda_handler # in go this is the compiled binary, python it's filename.function
        memory_size: 256
        # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
        runtime: python3.9
        package_type: Zip # `Zip` or `Image`
        policy_json: null

        # Filename example
        filename: lambdas/hello-world-python/output.zip # generated by zip variable.
        zip:
          enabled: true
          input_dir: hello-world-python
          output: hello-world-python/output.zip

        # S3 Source Example
        # s3_bucket_name: lambda-source # lambda main.tf calculates the rest of the bucket_name
        # s3_key: hello-world-go.zip
```

this stack configuration lead to error

```
│ Error: Missing required argument
│ 
│   with module.lambda.aws_lambda_function.this[0],
│   on .terraform/modules/lambda/main.tf line 40, in resource "aws_lambda_function" "this":
│   40:   s3_key                         = var.s3_key
│ 
│ "s3_key": all of `s3_bucket,s3_key` must be specified
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved deployment configuration handling so storage key assignment is skipped when no storage bucket is configured, preventing invalid configuration and preserving prior behavior when a bucket is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->