### PR TITLE
Guard resources against enabled: false

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,10 @@ locals {
 
   s3_bucket_name = var.s3_bucket_name != null ? var.s3_bucket_name : one(module.s3_bucket[*].outputs.bucket_id)
 
-  function_name = coalesce(var.function_name, module.this.id)
+  function_name        = local.enabled ? coalesce(var.function_name, module.this.id) : ""
+  function_url_enabled = local.enabled && var.function_url_enabled
+
+  cloudwatch_event_rules = local.enabled ? var.cloudwatch_event_rules : {}
 
   var_policy_json = local.var_iam_policy_enabled ? [var.policy_json] : []
 
@@ -83,7 +86,7 @@ module "lambda" {
   image_uri          = local.image_uri
   image_config       = var.image_config
 
-  filename          = var.zip.enabled ? coalesce(data.archive_file.lambdazip[0].output_path, var.filename) : var.filename
+  filename          = local.enabled && var.zip.enabled ? coalesce(data.archive_file.lambdazip[0].output_path, var.filename) : var.filename
   s3_bucket         = local.s3_bucket_name
   s3_key            = local.s3_key
   s3_object_version = var.s3_object_version
@@ -114,7 +117,7 @@ module "lambda" {
 }
 
 resource "aws_lambda_function_url" "lambda_url" {
-  count              = var.function_url_enabled ? 1 : 0
+  count              = local.function_url_enabled ? 1 : 0
   function_name      = module.lambda.function_name
   authorization_type = "AWS_IAM"
 

--- a/src/triggers_cloudwatch_event_rules.tf
+++ b/src/triggers_cloudwatch_event_rules.tf
@@ -1,5 +1,5 @@
 module "cloudwatch_event_rules_label" {
-  for_each = var.cloudwatch_event_rules
+  for_each = local.cloudwatch_event_rules
 
   source     = "cloudposse/label/null"
   version    = "0.25.0"
@@ -9,7 +9,7 @@ module "cloudwatch_event_rules_label" {
 }
 
 resource "aws_cloudwatch_event_rule" "event_rules" {
-  for_each = var.cloudwatch_event_rules
+  for_each = local.cloudwatch_event_rules
 
   name = module.cloudwatch_event_rules_label[each.key].id
 
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_event_rule" "event_rules" {
 }
 
 resource "aws_cloudwatch_event_target" "sns" {
-  for_each = var.cloudwatch_event_rules
+  for_each = local.cloudwatch_event_rules
 
   rule      = aws_cloudwatch_event_rule.event_rules[each.key].name
   target_id = "ScheduleExpression"
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_event_target" "sns" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
-  for_each = var.cloudwatch_event_rules
+  for_each = local.cloudwatch_event_rules
 
   statement_id  = format("%s-%s", "AllowExecutionFromCloudWatch", each.key)
   action        = "lambda:InvokeFunction"


### PR DESCRIPTION
## What

Gate `function_name`, `function_url_enabled`, and `cloudwatch_event_rules` locals on `local.enabled` so dependent resources are not created when the component is disabled. Guard `filename` zip reference with `local.enabled` to prevent index errors. Switch all `for_each` in `triggers_cloudwatch_event_rules.tf` from `var.cloudwatch_event_rules` to `local.cloudwatch_event_rules`.

## Why

Setting `enabled: false` on a Lambda component causes plan/destroy errors because resources like CloudWatch event rules, function URLs, and zip archives still attempt to reference or create resources that don't exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Lambda function and CloudWatch event rule resources from being created when feature gates are disabled.
  * Improved conditional resource provisioning logic to respect configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->